### PR TITLE
8 8 documentar endpoints con swagger

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -5,6 +5,7 @@ import { createConnection } from './config/dbConfig.js';
 dotenv.config();
 
 const PORT = process.env.PORT || 3000;
+const HOST = process.env.HOST || 'localhost';
 
 const startServer = async () => {
   try {
@@ -15,8 +16,8 @@ const startServer = async () => {
     // Iniciar el servidor
     app.listen(PORT, () => {
       console.log('\n==================================================');
-      console.log(`🚀 Servidor corriendo en: http://localhost:${PORT}`);
-      console.log(`📃 Swagger Docs: http://localhost:${PORT}/api-docs`);
+      console.log(`🚀 Servidor corriendo en: http://${HOST}:${PORT}`);
+      console.log(`📃 Swagger Docs: http://${HOST}:${PORT}/api-docs`);
       console.log('==================================================\n');
     });
   } catch (error) {

--- a/backend/swagger/v1/components/schemas/links/Link.js
+++ b/backend/swagger/v1/components/schemas/links/Link.js
@@ -1,0 +1,12 @@
+const Link = {
+    type: 'object',
+    properties: {
+        id_link: { type: 'integer', example: 1 },
+        titulo: { type: 'string', example: 'Mi enlace interesante' },
+        descripcion: { type: 'string', example: 'Un enlace útil para aprender algo nuevo.' },
+        id_categoria: { type: 'integer', example: 3 },
+        url: { type: 'string', example: 'https://mi-enlace.com' }
+    }
+};
+
+export default Link;

--- a/backend/swagger/v1/components/schemas/links/LinkInput.js
+++ b/backend/swagger/v1/components/schemas/links/LinkInput.js
@@ -1,0 +1,12 @@
+const LinkInput = {
+    type: 'object',
+    properties: {
+        titulo: { type: 'string', example: 'Título del link' },
+        descripcion: { type: 'string', example: 'Descripción del link' },
+        id_categoria: { type: 'integer', example: 2 },
+        url: { type: 'string', example: 'https://mi-enlace.com' }
+    },
+    required: ['titulo', 'descripcion', 'id_categoria', 'url']
+};
+
+export default LinkInput;

--- a/backend/swagger/v1/components/schemas/video/VideoInput.js
+++ b/backend/swagger/v1/components/schemas/video/VideoInput.js
@@ -2,6 +2,7 @@
 
 const VideoInput = {
     type: 'object',
+    required: ["title", "description", " url"],
     properties: {
         title: {
             type: 'string',
@@ -16,7 +17,6 @@ const VideoInput = {
             description: 'URL del video'
         }
     },
-    required: ['title', 'url']
 };
 
 export default VideoInput;

--- a/backend/swagger/v1/paths/links/createLink.js
+++ b/backend/swagger/v1/paths/links/createLink.js
@@ -1,0 +1,41 @@
+const createLink = {
+    summary: 'Crea un nuevo link',
+    description: 'Permite crear un nuevo link en la base de datos.',
+    tags: ['Links'], 
+    requestBody: {
+        required: true,
+        content: {
+            'application/json': {
+                schema: {
+                    $ref: '#/components/schemas/LinkInput'
+                },
+                example: {
+                    titulo: "Mi enlace interesante",
+                    descripcion: "Un enlace útil para aprender algo nuevo.",
+                    id_categoria: 3,
+                    url: "https://mi-enlace.com"
+                }
+            }
+        }
+    },
+    responses: {
+        201: {
+            description: 'Link creado exitosamente',
+            content: {
+                'application/json': {
+                    schema: {
+                        $ref: '#/components/schemas/Link'
+                    }
+                }
+            }
+        },
+        400: {
+            description: 'Solicitud incorrecta o conflicto de datos'
+        },
+        500: {
+            description: 'Error interno del servidor'
+        }
+    }
+};
+
+export default createLink;

--- a/backend/swagger/v1/paths/links/deleteLink.js
+++ b/backend/swagger/v1/paths/links/deleteLink.js
@@ -1,0 +1,30 @@
+const deleteLink = {
+    summary: 'Elimina un link por ID',
+    description: 'Permite eliminar un link específico de la base de datos.',
+    tags: ['Links'], 
+    parameters: [
+        {
+            name: 'linkId',
+            in: 'path',
+            description: 'ID del link a eliminar',
+            required: true,
+            schema: {
+                type: 'integer',
+                example: 3
+            }
+        }
+    ],
+    responses: {
+        200: {
+            description: 'Link eliminado exitosamente'
+        },
+        404: {
+            description: 'Link no encontrado'
+        },
+        500: {
+            description: 'Error interno del servidor'
+        }
+    }
+};
+
+export default deleteLink;

--- a/backend/swagger/v1/paths/links/getAllLinks.js
+++ b/backend/swagger/v1/paths/links/getAllLinks.js
@@ -1,0 +1,22 @@
+export const getAllLinks = {
+    summary: 'Obtiene todos los links',
+    description: 'Este endpoint devuelve todos los links registrados.',
+    tags: ['Links'], 
+    responses: {
+        200: {
+            description: 'Lista de links',
+            content: {
+                'application/json': {
+                    schema: {
+                        type: 'array',
+                        items: {
+                            $ref: '#/components/schemas/Link'
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+export default getAllLinks;

--- a/backend/swagger/v1/paths/links/getLinkById.js
+++ b/backend/swagger/v1/paths/links/getLinkById.js
@@ -1,0 +1,37 @@
+const getLinkById = {
+    summary: 'Obtiene un link por ID',
+    description: 'Devuelve los detalles de un link específico por su ID.',
+    tags: ['Links'], 
+    parameters: [
+        {
+            name: 'linkId',
+            in: 'path',
+            description: 'ID del link a buscar',
+            required: true,
+            schema: {
+                type: 'integer',
+                example: 3
+            }
+        }
+    ],
+    responses: {
+        200: {
+            description: 'Detalles del link obtenidos exitosamente',
+            content: {
+                'application/json': {
+                    schema: {
+                        $ref: '#/components/schemas/Link'
+                    }
+                }
+            }
+        },
+        404: {
+            description: 'Link no encontrado'
+        },
+        500: {
+            description: 'Error interno del servidor'
+        }
+    }
+};
+
+export default getLinkById;

--- a/backend/swagger/v1/paths/links/updateLink.js
+++ b/backend/swagger/v1/paths/links/updateLink.js
@@ -1,0 +1,56 @@
+const updateLink = {
+    summary: 'Actualiza un link por ID',
+    description: 'Permite actualizar un link específico en la base de datos.',
+    tags: ['Links'], 
+    parameters: [
+        {
+            name: 'linkId',
+            in: 'path',
+            description: 'ID del link a actualizar',
+            required: true,
+            schema: {
+                type: 'integer',
+                example: 3
+            }
+        }
+    ],
+    requestBody: {
+        required: true,
+        content: {
+            'application/json': {
+                schema: {
+                    $ref: '#/components/schemas/LinkInput'
+                },
+                example: {
+                    titulo: "Título actualizado",
+                    descripcion: "Descripción actualizada del link.",
+                    id_categoria: 2,
+                    url: "https://mi-enlace-actualizado.com"
+                }
+            }
+        }
+    },
+    responses: {
+        200: {
+            description: 'Link actualizado exitosamente',
+            content: {
+                'application/json': {
+                    schema: {
+                        $ref: '#/components/schemas/Link'
+                    }
+                }
+            }
+        },
+        400: {
+            description: 'Solicitud incorrecta o conflicto de datos'
+        },
+        404: {
+            description: 'Link no encontrado'
+        },
+        500: {
+            description: 'Error interno del servidor'
+        }
+    }
+};
+
+export default updateLink;

--- a/backend/swagger/v1/paths/videos/createVideo.js
+++ b/backend/swagger/v1/paths/videos/createVideo.js
@@ -8,7 +8,13 @@ const createVideo = {
         content: {
             'application/json': {
                 schema: {
-                    $ref: '#/components/schemas/video/VideoInput'
+                    $ref: '#/components/schemas/VideoInput'
+                },
+                example: {
+                    titulo: "String",
+                    descripcion: "String",
+                    id_categoria: 1,
+                    url: "String"
                 }
             }
         }
@@ -19,7 +25,7 @@ const createVideo = {
             content: {
                 'application/json': {
                     schema: {
-                        $ref: '#/components/schemas/video/Video'
+                        $ref: '#/components/schemas/Video'
                     }
                 }
             }

--- a/backend/swagger/v1/paths/videos/createVideo.js
+++ b/backend/swagger/v1/paths/videos/createVideo.js
@@ -3,6 +3,7 @@
 const createVideo = {
     summary: 'Crea un nuevo video',
     description: 'Este endpoint permite crear un nuevo video en la base de datos.',
+    tags: ['Videos'],
     requestBody: {
         required: true,
         content: {
@@ -13,7 +14,7 @@ const createVideo = {
                 example: {
                     titulo: "String",
                     descripcion: "String",
-                    id_categoria: 1,
+                    id_categoria: 4,
                     url: "String"
                 }
             }

--- a/backend/swagger/v1/paths/videos/deleteVideo.js
+++ b/backend/swagger/v1/paths/videos/deleteVideo.js
@@ -3,6 +3,7 @@
 const deleteVideo = {
     summary: 'Elimina un video por ID',
     description: 'Este endpoint elimina un video basado en su ID.',
+    tags: ['Videos'],
     parameters: [
         {
             name: 'videoId',
@@ -10,7 +11,8 @@ const deleteVideo = {
             description: 'ID del video a eliminar',
             required: true,
             schema: {
-                type: 'string'
+                type: 'string',
+                example: 4
             }
         }
     ],

--- a/backend/swagger/v1/paths/videos/getAllVideos.js
+++ b/backend/swagger/v1/paths/videos/getAllVideos.js
@@ -11,7 +11,7 @@ const getAllVideos = {
                     schema: {
                         type: 'array',
                         items: {
-                            $ref: '#/components/schemas/video/Video'
+                            $ref: '#/components/schemas/Video'
                         }
                     }
                 }

--- a/backend/swagger/v1/paths/videos/getAllVideos.js
+++ b/backend/swagger/v1/paths/videos/getAllVideos.js
@@ -3,6 +3,7 @@
 const getAllVideos = {
     summary: 'Obtiene todos los videos',
     description: 'Este endpoint devuelve todos los videos disponibles en la base de datos.',
+    tags: ['Videos'],
     responses: {
         200: {
             description: 'Lista de videos',

--- a/backend/swagger/v1/paths/videos/getVideoById.js
+++ b/backend/swagger/v1/paths/videos/getVideoById.js
@@ -3,6 +3,7 @@
 const getVideoById = {
     summary: 'Obtiene un video por ID',
     description: 'Este endpoint devuelve un video específico basándose en su ID.',
+    tags: ['Videos'],
     parameters: [
         {
             name: 'videoId',
@@ -10,7 +11,8 @@ const getVideoById = {
             description: 'ID del video',
             required: true,
             schema: {
-                type: 'string'
+                type: 'string',
+                example: 4
             }
         }
     ],

--- a/backend/swagger/v1/paths/videos/getVideoById.js
+++ b/backend/swagger/v1/paths/videos/getVideoById.js
@@ -20,7 +20,7 @@ const getVideoById = {
             content: {
                 'application/json': {
                     schema: {
-                        $ref: '#/components/schemas/video/Video'
+                        $ref: '#/components/schemas/Video'
                     }
                 }
             }

--- a/backend/swagger/v1/paths/videos/updateVideo.js
+++ b/backend/swagger/v1/paths/videos/updateVideo.js
@@ -1,5 +1,3 @@
-// swagger/v1/paths/videos/updateVideo.js
-
 const updateVideo = {
     summary: 'Actualiza un video por ID',
     description: 'Este endpoint permite actualizar los detalles de un video basado en su ID.',
@@ -10,7 +8,8 @@ const updateVideo = {
             description: 'ID del video a actualizar',
             required: true,
             schema: {
-                type: 'string'
+                type: 'integer',
+                example: 123 // Ejemplo del ID del video
             }
         }
     ],
@@ -19,7 +18,13 @@ const updateVideo = {
         content: {
             'application/json': {
                 schema: {
-                    $ref: '#/components/schemas/video/VideoUpdateInput'
+                    $ref: '#/components/schemas/VideoUpdateInput'
+                },
+                example: {
+                    titulo: "Actualización de título",
+                    descripcion: "Descripción actualizada del video.",
+                    id_categoria: 2,
+                    url: "https://mi-servidor.com/videos/actualizacion-titulo"
                 }
             }
         }
@@ -30,7 +35,7 @@ const updateVideo = {
             content: {
                 'application/json': {
                     schema: {
-                        $ref: '#/components/schemas/video/Video'
+                        $ref: '#/components/schemas/Video'
                     }
                 }
             }

--- a/backend/swagger/v1/paths/videos/updateVideo.js
+++ b/backend/swagger/v1/paths/videos/updateVideo.js
@@ -1,6 +1,7 @@
 const updateVideo = {
     summary: 'Actualiza un video por ID',
     description: 'Este endpoint permite actualizar los detalles de un video basado en su ID.',
+    tags: ['Videos'],
     parameters: [
         {
             name: 'videoId',
@@ -9,7 +10,7 @@ const updateVideo = {
             required: true,
             schema: {
                 type: 'integer',
-                example: 123 // Ejemplo del ID del video
+                example: 4
             }
         }
     ],

--- a/backend/swagger/v1/swaggerSpec.js
+++ b/backend/swagger/v1/swaggerSpec.js
@@ -10,11 +10,18 @@ import getVideoById from './paths/videos/getVideoById.js';
 import createVideo from './paths/videos/createVideo.js';
 import updateVideo from './paths/videos/updateVideo.js';
 import deleteVideo from './paths/videos/deleteVideo.js';
+import getAllLinks from './paths/links/getAllLinks.js';
+import getLinkById from './paths/links/getLinkById.js';
+import createLink from './paths/links/createLink.js';
+import updateLink from './paths/links/updateLink.js';
+import deleteLink from './paths/links/deleteLink.js';
 
 // Importar los esquemas de los modelos (schemas)
 import Video from './components/schemas/video/Video.js';
 import VideoInput from './components/schemas/video/VideoInput.js';
 import VideoUpdateInput from './components/schemas/video/VideoUpdateInput.js';
+import Link from './components/schemas/links/Link.js';
+import LinkInput from './components/schemas/links/LinkInput.js';
 
 // Importar los esquemas de seguridad
 
@@ -25,6 +32,7 @@ const swaggerSpec = {
     info,
     servers,
     paths: {
+        // Rutas de videos
         '/resources/videos': {
             get: getAllVideos,
             post: createVideo
@@ -33,13 +41,29 @@ const swaggerSpec = {
             get: getVideoById,
             put: updateVideo,
             delete: deleteVideo
+        },
+
+        // Rutas de links
+        '/resources/links': {
+            get: getAllLinks,
+            post: createLink
+        },
+        '/resources/links/{linkId}': {
+            get: getLinkById,
+            put: updateLink,
+            delete: deleteLink
         }
     },
     components: {
         schemas: {
+            // Esquemas de videos
             Video,
             VideoInput,
-            VideoUpdateInput
+            VideoUpdateInput,
+
+            // Esquemas de links
+            Link,
+            LinkInput
         },
         securitySchemes: {
         }


### PR DESCRIPTION
Agregar rutas y documentación Swagger para videos y links

- Se añadieron las rutas para gestionar videos y links en la API.
- Se implementaron los endpoints CRUD para videos y links con sus respectivas respuestas y parámetros.
- Se agregó el archivo Swagger para configurar la documentación de la API.
- Se incluyeron etiquetas en las rutas para agrupar y diferenciar los recursos de Videos y Links en la UI de Swagger.
- Se definieron los esquemas necesarios para Videos y Links en Swagger.
- Se organizaron las rutas y la configuración de Swagger para un mejor mantenimiento y claridad.

Rutas añadidas:
- /resources/videos (GET, POST)
- /resources/videos/{videoId} (GET, PUT, DELETE)
- /resources/links (GET, POST)
- /resources/links/{linkId} (GET, PUT, DELETE)